### PR TITLE
Delete Install LICENSE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ install:
 	install -Dm 755 scripts/displayimg $(DEST)/displayimg
 	install -Dm 755 scripts/displayimg_uberzug $(DEST)/displayimg_uberzug
 	install -Dm 755 scripts/clearimg_uberzug $(DEST)/clearimg_uberzug
-	install -Dm 644 LICENSE /usr/share/licenses/$(PROG)/LICENSE
 	install -Dm 644 cfiles.1 /usr/local/man/man1/cfiles.1
 
 uninstall:
@@ -31,5 +30,4 @@ uninstall:
 	rm -v $(DEST)/clearimg_uberzug
 	rm -v $(DEST)/displayimg_uberzug
 	rm -v $(DEST)/displayimg
-	rm -v /usr/share/licenses/$(PROG)/LICENSE
 	rm -v /usr/local/man/man1/cfiles.1


### PR DESCRIPTION
Deleted a line about install LICENSE because it is unnecessary.
The place of stored license depends each distribution.