### PR TITLE
README.md incorrectly references $XDG_CACHE_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,19 +79,19 @@ to install.
 | <kbd>q</kbd> | Quit |
 
 ## Directories Used
-`cfiles` uses `$XDG_CONFIG/cfiles` directory to store the clipboard file. This is used so that the clipboard
+`cfiles` uses `$XDG_CONFIG_HOME/cfiles` directory to store the clipboard file. This is used so that the clipboard
 can be shared between multiple instances of `cfiles`. That's why I won't be adding tabs in `cfiles` because multiple
 instances can be openend and managed by any terminal multiplexer or your window manager.
 Note that this also means the selection list will persist even if all instances are closed.
 
 `cfiles` also uses `$HOME/.local/share/Trash/files` as the Trash Directory, so make sure this directory exists before you try to delete a file.
 
-For storing bookmarks, `cfiles` uses `$XDG_CONFIG/cfiles/bookmarks` file. Bookmarks are stored in the form `<key>:<path>`. You can either edit this file directly
+For storing bookmarks, `cfiles` uses `$XDG_CONFIG_HOME/cfiles/bookmarks` file. Bookmarks are stored in the form `<key>:<path>`. You can either edit this file directly
 or press `m` in `cfiles` to add new bookmarks.
 
-`cfiles` looks for external scripts in the `$XDG_CONFIG/cfiles/scripts` directory. Make sure the scripts are executable before moving them to the scripts directory.
+`cfiles` looks for external scripts in the `$XDG_CONFIG_HOME/cfiles/scripts` directory. Make sure the scripts are executable before moving them to the scripts directory.
 
-If `$XDG_CONFIG` is not set, then `$HOME/.config` is used.
+If `$XDG_CONFIG_HOME` is not set, then `$HOME/.config` is used.
 
 ## Opening Files
 You can set `FILE_OPENER` in `config.h` to specify your file opening program. It is set to use `xdg-open` by default but you can change it to anything like `thunar`. macOS users need to set it to `open`.

--- a/README.md
+++ b/README.md
@@ -79,19 +79,19 @@ to install.
 | <kbd>q</kbd> | Quit |
 
 ## Directories Used
-`cfiles` uses `$XDG_CACHE_HOME/cfiles` directory to store the clipboard file. This is used so that the clipboard
+`cfiles` uses `$XDG_CONFIG/cfiles` directory to store the clipboard file. This is used so that the clipboard
 can be shared between multiple instances of `cfiles`. That's why I won't be adding tabs in `cfiles` because multiple
 instances can be openend and managed by any terminal multiplexer or your window manager.
 Note that this also means the selection list will persist even if all instances are closed.
 
 `cfiles` also uses `$HOME/.local/share/Trash/files` as the Trash Directory, so make sure this directory exists before you try to delete a file.
 
-For storing bookmarks, `cfiles` uses `$XDG_CACHE_HOME/cfiles/bookmarks` file. Bookmarks are stored in the form `<key>:<path>`. You can either edit this file directly
+For storing bookmarks, `cfiles` uses `$XDG_CONFIG/cfiles/bookmarks` file. Bookmarks are stored in the form `<key>:<path>`. You can either edit this file directly
 or press `m` in `cfiles` to add new bookmarks.
 
-`cfiles` looks for external scripts in the `$XDG_CACHE_HOME/cfiles/scripts` directory. Make sure the scripts are executable before moving them to the scripts directory.
+`cfiles` looks for external scripts in the `$XDG_CONFIG/cfiles/scripts` directory. Make sure the scripts are executable before moving them to the scripts directory.
 
-If `$XDG_CACHE_HOME` is not set, then `$HOME/.cache` is used.
+If `$XDG_CONFIG` is not set, then `$HOME/.config` is used.
 
 ## Opening Files
 You can set `FILE_OPENER` in `config.h` to specify your file opening program. It is set to use `xdg-open` by default but you can change it to anything like `thunar`. macOS users need to set it to `open`.


### PR DESCRIPTION
README.md mentions $XDG_CACHE_HOME and $HOME/.cache. These should instead be $XDG_CONFIG_HOME and $HOME/.config